### PR TITLE
Fixed schema to use accountID and locationID as composite keys

### DIFF
--- a/lambda/internal/models/unit.go
+++ b/lambda/internal/models/unit.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -24,8 +25,9 @@ type AcesAttribute struct {
 // Unit represents a commercial vehicle type unit in DynamoDB
 type Unit struct {
 	// DynamoDB key fields
-	ID        string `json:"id" dynamodbav:"pk"`        // Primary Key (UUID)
-	AccountID string `json:"accountId" dynamodbav:"sk"` // Sort Key
+	ID         string `json:"id" dynamodbav:"id"`         // Unit UUID
+	AccountID  string `json:"accountId" dynamodbav:"pk"`  // Primary Key
+	LocationID string `json:"locationId" dynamodbav:"sk"` // Sort Key
 
 	// Core identification fields
 	SuggestedVin      string `json:"suggestedVin" dynamodbav:"suggestedVin"`
@@ -238,8 +240,8 @@ type Unit struct {
 // GetKey returns the composite primary key for DynamoDB operations (PK + SK)
 func (u *Unit) GetKey() map[string]types.AttributeValue {
 	key, _ := attributevalue.MarshalMap(map[string]interface{}{
-		"pk": u.ID,        // Primary Key (UUID)
-		"sk": u.AccountID, // Sort Key (AccountID)
+		"pk": u.AccountID,  // Primary Key (AccountID)
+		"sk": u.LocationID, // Sort Key (LocationID)
 	})
 	return key
 }
@@ -266,4 +268,15 @@ func (u *Unit) MarkDeleted() {
 // GenerateID generates a new UUID for the unit's primary key
 func (u *Unit) GenerateID() {
 	u.ID = uuid.New().String()
+}
+
+// ValidateLocationID validates that the LocationID is a valid UUID
+func (u *Unit) ValidateLocationID() error {
+	if u.LocationID == "" {
+		return fmt.Errorf("locationId is required")
+	}
+	if _, err := uuid.Parse(u.LocationID); err != nil {
+		return fmt.Errorf("locationId must be a valid UUID: %w", err)
+	}
+	return nil
 }

--- a/lambda/internal/repository/mock_unit_repository.go
+++ b/lambda/internal/repository/mock_unit_repository.go
@@ -21,8 +21,17 @@ func (m *MockUnitRepository) Create(ctx context.Context, unit *models.Unit) erro
 }
 
 // GetByKey mocks the GetByKey method
-func (m *MockUnitRepository) GetByKey(ctx context.Context, id, accountID string) (*models.Unit, error) {
-	args := m.Called(ctx, id, accountID)
+func (m *MockUnitRepository) GetByKey(ctx context.Context, accountID, locationID string) (*models.Unit, error) {
+	args := m.Called(ctx, accountID, locationID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Unit), args.Error(1)
+}
+
+// GetByID mocks the GetByID method
+func (m *MockUnitRepository) GetByID(ctx context.Context, accountID, unitID string) (*models.Unit, error) {
+	args := m.Called(ctx, accountID, unitID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -36,8 +45,8 @@ func (m *MockUnitRepository) Update(ctx context.Context, unit *models.Unit) erro
 }
 
 // Delete mocks the Delete method
-func (m *MockUnitRepository) Delete(ctx context.Context, id, accountID string) error {
-	args := m.Called(ctx, id, accountID)
+func (m *MockUnitRepository) Delete(ctx context.Context, accountID, locationID string) error {
+	args := m.Called(ctx, accountID, locationID)
 	return args.Error(0)
 }
 
@@ -51,7 +60,7 @@ func (m *MockUnitRepository) List(ctx context.Context, input *appsync.ListUnitsI
 }
 
 // Exists mocks the Exists method
-func (m *MockUnitRepository) Exists(ctx context.Context, id, accountID string) (bool, error) {
-	args := m.Called(ctx, id, accountID)
+func (m *MockUnitRepository) Exists(ctx context.Context, accountID, locationID string) (bool, error) {
+	args := m.Called(ctx, accountID, locationID)
 	return args.Bool(0), args.Error(1)
 }

--- a/lambda/internal/repository/unit_repository.go
+++ b/lambda/internal/repository/unit_repository.go
@@ -12,18 +12,21 @@ type UnitRepository interface {
 	// Create creates a new unit in the repository
 	Create(ctx context.Context, unit *models.Unit) error
 
-	// GetByKey retrieves a unit by its composite primary key (id + accountId)
-	GetByKey(ctx context.Context, id, accountID string) (*models.Unit, error)
+	// GetByKey retrieves a unit by its composite primary key (accountId + locationId)
+	GetByKey(ctx context.Context, accountID, locationID string) (*models.Unit, error)
+
+	// GetByID retrieves a unit by its unique ID within an account
+	GetByID(ctx context.Context, accountID, unitID string) (*models.Unit, error)
 
 	// Update updates an existing unit in the repository
 	Update(ctx context.Context, unit *models.Unit) error
 
 	// Delete soft deletes a unit (marks deletedAt timestamp)
-	Delete(ctx context.Context, id, accountID string) error
+	Delete(ctx context.Context, accountID, locationID string) error
 
 	// List retrieves a paginated list of units for an account
 	List(ctx context.Context, input *appsync.ListUnitsInput) (*appsync.ListUnitsResponse, error)
 
 	// Exists checks if a unit exists by its composite primary key
-	Exists(ctx context.Context, id, accountID string) (bool, error)
+	Exists(ctx context.Context, accountID, locationID string) (bool, error)
 }

--- a/lambda/pkg/appsync/events.go
+++ b/lambda/pkg/appsync/events.go
@@ -77,14 +77,14 @@ const (
 
 // CreateUnitInput represents input for creating a unit
 type CreateUnitInput struct {
-	AccountID string `json:"accountId"`
+	AccountID   string `json:"accountId"`
 	models.Unit        // Embed Unit fields directly
 }
 
 // UpdateUnitInput represents input for updating a unit
 type UpdateUnitInput struct {
-	ID        string `json:"id"`
-	AccountID string `json:"accountId"`
+	ID          string `json:"id"`
+	AccountID   string `json:"accountId"`
 	models.Unit        // Embed Unit fields directly
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,10 +36,15 @@ resource "aws_dynamodb_table" "units_table" {
     type = "S"
   }
 
-  # Global Secondary Index for querying by account ID
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  # Global Secondary Index for querying by unit ID
   global_secondary_index {
-    name            = "sk-index"
-    hash_key        = "sk"
+    name            = "id-index"
+    hash_key        = "id"
     projection_type = "ALL"
 
     # Only set capacity if using PROVISIONED billing mode

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -15,7 +15,7 @@ output "dynamodb_table_id" {
 
 output "dynamodb_gsi_name" {
   description = "Name of the DynamoDB Global Secondary Index"
-  value       = "sk-index"
+  value       = "id-index"
 }
 
 output "lambda_function_name" {


### PR DESCRIPTION
This pull request refactors the unit handling logic in `lambda/internal/handlers/unit_handlers.go` and its corresponding tests. The changes improve repository method consistency, enhance validation checks, and update the `Unit` model structure to better align with DynamoDB schema. 

### Refactor of Repository Methods:
* Updated repository method calls from `GetByKey` to `GetByID` for consistency and clarity in unit retrieval operations across `HandleRead`, `HandleUpdate`, and `HandleDelete`. [[1]](diffhunk://#diff-1ac3e65d923f625ecfaf3084a661d47cff3545dd97cd6e5203dc882d058f374aL94-R95) [[2]](diffhunk://#diff-1ac3e65d923f625ecfaf3084a661d47cff3545dd97cd6e5203dc882d058f374aL138-R139) [[3]](diffhunk://#diff-1ac3e65d923f625ecfaf3084a661d47cff3545dd97cd6e5203dc882d058f374aR233-R245)

### Model Schema Update:
* Modified the `Unit` model in `lambda/internal/models/unit.go` to include `LocationID` as the sort key (`sk`) and changed `AccountID` to the primary key (`pk`) for better DynamoDB schema alignment.

### Enhanced Unit Deletion Logic:
* Added a preliminary step in `HandleDelete` to retrieve the unit by `GetByID` before deletion, ensuring the `LocationID` is available for the delete operation.

### Test Updates for Refactored Logic:
* Refactored tests to use `GetByID` instead of `GetByKey` and updated mock expectations accordingly. Added validation for new `LocationID` field in test inputs. [[1]](diffhunk://#diff-0f0e6e5b4d63910551b514e2c3c1fa5f3259712b1a9f7b76653ad587e0314f87L196-R196) [[2]](diffhunk://#diff-0f0e6e5b4d63910551b514e2c3c1fa5f3259712b1a9f7b76653ad587e0314f87L592-R590) F646e2c0L719R774)

### Validation and Error Handling Improvements:
* Improved validation checks in `HandleDelete` to ensure the unit exists before attempting deletion. Added error handling for cases where `GetByID` fails or returns `nil`. ([lambda/internal/handlers/unit_handlers.goR233-R245](diffhunk://#diff-1ac3e65d923f625ecfaf3084a661d47cff3545dd97cd6e5203dc882d058f374aR233-R245), F646e2c0L719R774)